### PR TITLE
Feat: Implement CSS Grid for equal height team cards

### DIFF
--- a/header.php
+++ b/header.php
@@ -89,7 +89,10 @@
         }
 
         .teams {
-            display: block;
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+            gap: 20px;
+            align-items: stretch;
         }
 
         img {


### PR DESCRIPTION
Here is a good title and description for your pull request.

Title: Feat: Implement CSS Grid for equal height team cards

Description:

(Copy and paste everything below into the description box on GitHub)

Fixes #1

Description
This pull request resolves the issue of unevenly sized team cards on the main page. Currently, the cards have varying heights depending on their content, which leads to a visually jarring layout.

This PR implements a CSS Grid layout for the card container. This ensures that all cards have a uniform height, creating a cleaner, more professional, and responsive appearance, regardless of content length.

How This Was Implemented
Added display: grid; to the .teams container class in header.php.

Used grid-template-columns to create a responsive column layout.

Applied align-items: stretch; to the grid container, which is the key property that forces all cards to stretch to the height of the tallest card in their row.